### PR TITLE
Fix build for Visual Studio on Windows.

### DIFF
--- a/libdatrie/datrie/dstring.c
+++ b/libdatrie/datrie/dstring.c
@@ -126,7 +126,7 @@ dstring_append (DString *dst, const DString *src)
         return FALSE;
     }
 
-    memcpy (dst->val + (dst->char_size * dst->str_len), src->val,
+    memcpy ((char *)dst->val + (dst->char_size * dst->str_len), (char *)src->val,
             (src->str_len + 1) * dst->char_size);
 
     dst->str_len += src->str_len;
@@ -140,7 +140,7 @@ dstring_append_string (DString *ds, const void *data, int len)
     if (!dstring_ensure_space (ds, (ds->str_len + len + 1) * ds->char_size))
         return FALSE;
 
-    memcpy (ds->val + (ds->char_size * ds->str_len), data, ds->char_size * len);
+    memcpy ((char *)ds->val + (ds->char_size * ds->str_len), data, ds->char_size * len);
 
     ds->str_len += len;
 
@@ -153,7 +153,7 @@ dstring_append_char (DString *ds, const void *data)
     if (!dstring_ensure_space (ds, (ds->str_len + 2) * ds->char_size))
         return FALSE;
 
-    memcpy (ds->val + (ds->char_size * ds->str_len), data, ds->char_size);
+    memcpy ((char *)ds->val + (ds->char_size * ds->str_len), data, ds->char_size);
 
     ds->str_len++;
 
@@ -166,7 +166,7 @@ dstring_terminate (DString *ds)
     if (!dstring_ensure_space (ds, (ds->str_len + 2) * ds->char_size))
         return FALSE;
 
-    memset (ds->val + (ds->char_size * ds->str_len), 0, ds->char_size);
+    memset ((char *)ds->val + (ds->char_size * ds->str_len), 0, ds->char_size);
 
     return TRUE;
 }


### PR DESCRIPTION
void \* arithmetic is a gcc extension. Cast the pointer to avoid compilation errors.
