### PR TITLE
Sort input file list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import os
 from setuptools import setup, Extension
 
 LIBDATRIE_DIR = 'libdatrie'
-LIBDATRIE_FILES = glob.glob(os.path.join(LIBDATRIE_DIR, "datrie", "*.c"))
+LIBDATRIE_FILES = sorted(glob.glob(os.path.join(LIBDATRIE_DIR, "datrie", "*.c")))
 
 DESCRIPTION = __doc__
 LONG_DESCRIPTION = open('README.rst').read() + open('CHANGES.rst').read()


### PR DESCRIPTION
so that datrie builds in a reproducible way
in spite of indeterministic filesystem readdir order
and http://bugs.python.org/issue30461