### PR TITLE
Remove deprecated 'average_size' argument from hypothesis tests

### DIFF
--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -13,7 +13,7 @@ if sys.version_info[:2] >= (2, 7):
     import hypothesis.strategies as st
     from hypothesis import given
 
-    printable_strings = st.lists(st.text(string.printable), average_size=5.)
+    printable_strings = st.lists(st.text(string.printable))
 
     @given(printable_strings)
     def test_contains(words):


### PR DESCRIPTION
The argument is deprecated and has no effect. Fixes warning:

    tests/test_random.py::test_contains
      .../hypothesis/internal/validation.py:157: HypothesisDeprecationWarning: You should remove the average_size argument, because it is deprecated and no longer has any effect.  Please open an issue if the default distribution of examples does not work for you.
        since="2018-03-10",