### PR TITLE
Remove workarounds for unsupported Pythons and update docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -302,7 +302,7 @@ Make sure `tox`_ is installed and run
 
     $ tox
 
-from the source checkout. Tests should pass under python 2.6, 2.7 and 3.2.
+from the source checkout. Tests should pass under Python 2.7, 3.4, 3.5, and 3.6.
 
 ::
 

--- a/setup.py
+++ b/setup.py
@@ -53,5 +53,6 @@ setup(name="datrie",
           ], include_dirs=[LIBDATRIE_DIR])
       ],
 
+      python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
       setup_requires=["pytest-runner"],
       tests_require=["pytest", "hypothesis"])

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -4,70 +4,67 @@ from __future__ import absolute_import, unicode_literals
 
 import pickle
 import string
-import sys
 
 import datrie
 
-# This is ugly, but hypothesis only supports Python2.7+ at the moment.
-if sys.version_info[:2] >= (2, 7):
-    import hypothesis.strategies as st
-    from hypothesis import given
+import hypothesis.strategies as st
+from hypothesis import given
 
-    printable_strings = st.lists(st.text(string.printable))
+printable_strings = st.lists(st.text(string.printable))
 
-    @given(printable_strings)
-    def test_contains(words):
-        trie = datrie.Trie(string.printable)
-        for i, word in enumerate(set(words)):
-            trie[word] = i + 1
+@given(printable_strings)
+def test_contains(words):
+    trie = datrie.Trie(string.printable)
+    for i, word in enumerate(set(words)):
+        trie[word] = i + 1
 
-        for i, word in enumerate(set(words)):
-            assert word in trie
-            assert trie[word] == trie.get(word) == i + 1
+    for i, word in enumerate(set(words)):
+        assert word in trie
+        assert trie[word] == trie.get(word) == i + 1
 
-    @given(printable_strings)
-    def test_len(words):
-        trie = datrie.Trie(string.printable)
-        for i, word in enumerate(set(words)):
-            trie[word] = i
+@given(printable_strings)
+def test_len(words):
+    trie = datrie.Trie(string.printable)
+    for i, word in enumerate(set(words)):
+        trie[word] = i
 
-        assert len(trie) == len(set(words))
+    assert len(trie) == len(set(words))
 
-    @given(printable_strings)
-    def test_pickle_unpickle(words):
-        trie = datrie.Trie(string.printable)
-        for i, word in enumerate(set(words)):
-            trie[word] = i
+@given(printable_strings)
+def test_pickle_unpickle(words):
+    trie = datrie.Trie(string.printable)
+    for i, word in enumerate(set(words)):
+        trie[word] = i
 
-        trie = pickle.loads(pickle.dumps(trie))
-        for i, word in enumerate(set(words)):
-            assert word in trie
-            assert trie[word] == i
+    trie = pickle.loads(pickle.dumps(trie))
+    for i, word in enumerate(set(words)):
+        assert word in trie
+        assert trie[word] == i
 
-    @given(printable_strings)
-    def test_pop(words):
-        words = set(words)
-        trie = datrie.Trie(string.printable)
-        for i, word in enumerate(words):
-            trie[word] = i
+@given(printable_strings)
+def test_pop(words):
+    words = set(words)
+    trie = datrie.Trie(string.printable)
+    for i, word in enumerate(words):
+        trie[word] = i
 
-        for i, word in enumerate(words):
-            assert trie.pop(word) == i
-            assert trie.pop(word, 42) == trie.get(word, 42) == 42
+    for i, word in enumerate(words):
+        assert trie.pop(word) == i
+        assert trie.pop(word, 42) == trie.get(word, 42) == 42
 
-    @given(printable_strings)
-    def test_clear(words):
-        words = set(words)
-        trie = datrie.Trie(string.printable)
-        for i, word in enumerate(words):
-            trie[word] = i
+@given(printable_strings)
+def test_clear(words):
+    words = set(words)
+    trie = datrie.Trie(string.printable)
+    for i, word in enumerate(words):
+        trie[word] = i
 
-        assert len(trie) == len(words)
-        trie.clear()
-        assert not trie
-        assert len(trie) == 0
+    assert len(trie) == len(words)
+    trie.clear()
+    assert not trie
+    assert len(trie) == 0
 
-        # make sure the trie works afterwards.
-        for i, word in enumerate(words):
-            trie[word] = i
-            assert trie[word] == i
+    # make sure the trie works afterwards.
+    for i, word in enumerate(words):
+        trie[word] = i
+        assert trie[word] == i

--- a/tests/test_trie.py
+++ b/tests/test_trie.py
@@ -405,10 +405,10 @@ class TestPrefixSearch(object):
 def test_trie_fuzzy():
     russian = 'абвгдеёжзиклмнопрстуфхцчъыьэюя'
     alphabet = russian.upper() + string.ascii_lowercase
-    words = list(set([
+    words = list({
         "".join(random.choice(alphabet) for x in range(random.randint(8, 16)))
         for y in range(1000)
-    ]))
+    })
 
     trie = datrie.Trie(alphabet)
 

--- a/tox-bench.ini
+++ b/tox-bench.ini
@@ -1,8 +1,6 @@
 [tox]
-envlist = py26,py27,py32,py33
+envlist = py27,py34,py35,py36
 
 [testenv]
-deps =
-    pytest
 commands=
     python bench/speed.py

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
-envlist = py26,py27,py32,py33,pypy
+envlist = py27,py34,py35,py36
 
 [testenv]
 deps =
+    hypothesis
     pytest
 commands=
     py.test []


### PR DESCRIPTION
Since commit d10efec0089dfe5e7139fc4ab2f00ff3623be0ec, the project only support Python 2.7 and 3.4+. This allows the project to clean up some code by removing a number of workarounds.

Updated the documentation that still referenced old Python versions.

Pass `python_requires` argument to setuptools to help pip decide what version of the library to install.

See https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires