### PR TITLE
Fix AlphaMap definition in cdatrie.pxd

### DIFF
--- a/src/cdatrie.pxd
+++ b/src/cdatrie.pxd
@@ -9,7 +9,7 @@ cdef extern from "../libdatrie/datrie/triedefs.h":
 
 cdef extern from "../libdatrie/datrie/alpha-map.h":
 
-    struct AlphaMap:
+    ctypedef struct AlphaMap:
         pass
 
     AlphaMap * alpha_map_new()


### PR DESCRIPTION
Fixes failure to compile on GCC with `-Werror=incompatible-pointer-types`.