### PR TITLE
Drop 3.13t wheel builds, add 3.14 and 3.14t tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14', '3.14t']
         include:
           # Intel runner
           - os: macos-15-intel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,5 +7,4 @@ requires = [
 
 [tool.cibuildwheel]
 build-frontend = "build[uv]"
-enable = ["cpython-freethreading"]
 environment-pass = ["SETUPTOOLS_SCM_PRETEND_VERSION"]


### PR DESCRIPTION
I'm going through projects on github that enable the cibuildwheel `cpython-freethreading` option and sending in PRs to remove it. The next release of cibuildwheel will remove the option:

https://cibuildwheel.pypa.io/en/stable/changelog/#v341

I also noticed there isn't yet and 3.14 or 3.14t CI testing, so I added that.